### PR TITLE
Type Safety for enumerable items

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,11 +145,25 @@ Releases for a browser are available for download from GitHub.
     Object.getOwnPropertyDescriptor(myEnum, 'Red'); //=> Object {value: EnumItem, writable: false, enumerable: true, configurable: false}
     Object.isExtensible(myEnum); //=> false
     myEnum instanceof Enum; //=> true
+
+    //Instances of Enum created with 'new' from similar objects are not equal
+    myEnum1=new Enum({'A':1, 'B':2, 'C':4});
+    myEnum2=new Enum({'A':1, 'B':2, 'C':4});
+    myEnum1 == myEnum2 //=> false
+    myEnum1.A == myEnum2.A //=> false
+    myEnum1.A.value == myEnum2.A.value //=> true
     
     //This enum object has no properties other than those defined during its creation. Existing Data is 'Persistent' and preserves the original version
-    myEnum.Red.value; //=> 2
-    myEnum.Red = 5; //=> doesn't change the original value 2
-    myEnum.Rainbow = 6 //=> doesn't add to the enum object
+    myEnum.B.value; //=> 2
+    myEnum.B = 5; //=> Throws TypeError
+    delete myEnum.B; //=> false
+    myEnum.D = 6; //=> doesn't add to the enum object, silently ignores
+    myEnum.D; // undefined
+
+    //Try to define new property throws TypeError
+    Object.defineProperty(myEnum, D, {value:6, writable:false, enumerable:true});
+    //=>TypeError: Cannot define property:D, object is not extensible.
+
 
 
 # License

--- a/README.md
+++ b/README.md
@@ -33,12 +33,27 @@ Releases for a browser are available for download from GitHub.
     require('enum').register();
 
     // define a simple enum (automatically flaggable -> A: 0x01, B: 0x02, C: 0x04)
+    //Uses bitwise 'OR' operation in between the values and creates enumerated constants. For example, if 'Read':1, 'Write':2, then ReadWrite= Read | Write = 1 | 2 = 3; 
     var myEnum = new Enum(['A', 'B', 'C']);
+    
+    //define a flagged enum object to create a multicolor option; just pass an array
+    var myEnum = new Enum([Black', 'Red', 'Green', 'Blue']);
+    myEnum; //=> Enum {_options: Object, enums: Array[4], Black: EnumItem, Red: EnumItem, Green: EnumItem….....}
+    myEnum.isFlaggable; //=> true
+
+    for(var i=1; i<8; i++){ console.log(myEnum.get(i).value + '=> '+ myEnum.get(i).key)}
+    1=> Black
+    2=> Red
+    3=> Black | Red
+    4=> Green
+    5=> Black | Green
+    6=> Red | Green
+    7=> Black | Red | Green
 
     // define an enum with own values
     var myEnum = new Enum({'A': 1, 'B': 2, 'C': 4});
 
-    // if defining an flaggable enum, you can define your own separator (default is ' | ')
+    // if defining a flaggable enum, you can define your own separator (default is ' | ')
     var myEnum = new Enum(['A', 'B', 'C'], { separator: ' | ' });
 
     // if you want your enum to have a name define it in the options
@@ -47,6 +62,18 @@ Releases for a browser are available for download from GitHub.
     // or
     var myEnum = new Enum(['A', 'B', 'C'], 'MyEnum');
 
+    //define enum type without flag
+    var myEnum = new Enum({'None': 0, 'Black':1, 'Red': 2, 'Red2': 3, 'Green': 4, 'Blue': 5});
+    myEnum; //=>  Enum {_options: Object, enums: Array[6], None: EnumItem, Black: EnumItem, Red: EnumItem…........}
+    myEnum.isFlaggable; //=> false
+
+    for(var i=0; i<=5; i++){ console.log(myEnum.get(i).value + '=> '+ myEnum.get(i).key)}
+    0=> None
+    1=> Black
+    2=> Red
+    3=> Red2
+    4=> Green
+    5=> Blue
 
     // get your item
     myEnum.A
@@ -111,6 +138,32 @@ Releases for a browser are available for download from GitHub.
     myItem.valueOf() // returns A | C
     
     JSON.stringify(myItem) // returns A | C
+
+    //Type Safety:
+    //Newly created enumerable objects are Type-Safe in a way that it's non-configurable and no longer extensible. 
+    //Each EnumItem has a beack-reference to a constructor and they are implicitly final.
+    Object.getOwnPropertyDescriptor(myEnum, 'Red'); //=> Object {value: EnumItem, writable: false, enumerable: true, configurable: false}
+    Object.isExtensible(myEnum); //=> false
+    myEnum instanceof Enum; //=> true
+
+    //Instances of Enum created with 'new' from similar objects are not equal
+    myEnum1=new Enum({'A':1, 'B':2, 'C':4});
+    myEnum2=new Enum({'A':1, 'B':2, 'C':4});
+    myEnum1 == myEnum2 //=> false
+    myEnum1.A == myEnum2.A //=> false
+    myEnum1.A.value == myEnum2.A.value //=> true
+    
+    //This enum object has no properties other than those defined during its creation. Existing Data is 'Persistent' and preserves the original version
+    myEnum.B.value; //=> 2
+    myEnum.B = 5; //=> Throws TypeError
+    delete myEnum.B; //=> false
+    myEnum.D = 6; //=> doesn't add to the enum object, silently ignores
+    myEnum.D; // undefined
+
+    //Try to define new property throws TypeError
+    Object.defineProperty(myEnum, D, {value:6, writable:false, enumerable:true});
+    //=>TypeError: Cannot define property:D, object is not extensible.
+
 
 
 # License

--- a/lib/enum.js
+++ b/lib/enum.js
@@ -14,6 +14,9 @@
 
   EnumItem.prototype = {
 
+    /*constructor reference so that, this.constructor===EnumItem//=>true */
+    constructor: EnumItem,
+
     /**
      * Checks if the flagged EnumItem has the passing object.
      * @param  {EnumItem || String || Number} value The object to check with.
@@ -122,9 +125,13 @@
     }
 
     this.isFlaggable = isFlaggable();
+    this.freezeEnums(); //this will make instances of Enum non-extensible
   }
 
   Enum.prototype = {
+
+    /*constructor reference so that, this.constructor===Enum//=>true */
+    constructor: EnumItem,
 
     /**
      * Returns the appropriate EnumItem key.
@@ -214,8 +221,32 @@
 
         return this.get(result || null);
       }
-    }
+    },
+    /*Define freezeEnums() as a property of the prototype.
+    make enumerable items nonconfigurable.
+    */
+freezeEnums: function(){
+  var freezer= function(o){
+                     var props = Object.getOwnPropertyNames(o);    
+    props.forEach( function(p){
+        if(!Object.getOwnPropertyDescriptor(o, p).configurable)
+          return;
+        Object.defineProperties(o, p, {writable:false, configurable:false});       
+        }) 
+return o;
+}
 
+var self = this;
+if(Object.freeze){
+    Object.freeze(self);
+    Object.freeze(self.enums);
+  }
+else{
+freezer(self);
+freezer(self.enums);
+}
+return self;
+}
   };
 
 

--- a/lib/enum.js
+++ b/lib/enum.js
@@ -223,10 +223,38 @@
       }
     },
     /*Define freezeEnums() as a property of the prototype.
-    make enumerable items nonconfigurable.
+    make enumerable items nonconfigurable and deep freeze the properties. Throw Error on property setter.
     */
 freezeEnums: function(){
-  var freezer= function(o){
+
+  deepFreezeEnums(this);
+  return this;
+
+  function deepFreezeEnums(o){
+    if(typeof o !== 'object' || o === null || Object.isFrozen(o) || Object.isSealed(o) ){
+      return;
+    }
+    for (var key in o){
+      if(o.hasOwnProperty(key)){
+        o.__defineGetter__(key, getPropertyValue.bind(null, o[key]));
+        o.__defineSetter__(key, function throwPropertySetError(value){throw TypeError("Cannot redefine property; Enum Type is not extensible.")});
+        deepFreezeEnums(o[key]);
+      }
+     }
+    if (Object.freeze){
+      Object.freeze(o);
+    }
+    else {
+      freezer(o);
+    }
+
+  }
+
+  function getPropertyValue(value){
+    return value;
+  }
+
+  function freezer(o){
                      var props = Object.getOwnPropertyNames(o);    
     props.forEach( function(p){
         if(!Object.getOwnPropertyDescriptor(o, p).configurable)
@@ -236,17 +264,7 @@ freezeEnums: function(){
 return o;
 }
 
-var self = this;
-if(Object.freeze){
-    Object.freeze(self);
-    Object.freeze(self.enums);
-  }
-else{
-freezer(self);
-freezer(self.enums);
-}
-return self;
-}
+},
   };
 
 

--- a/lib/enum.js
+++ b/lib/enum.js
@@ -131,7 +131,7 @@
   Enum.prototype = {
 
     /*constructor reference so that, this.constructor===Enum//=>true */
-    constructor: EnumItem,
+    constructor: Enum,
 
     /**
      * Returns the appropriate EnumItem key.

--- a/lib/enum.js
+++ b/lib/enum.js
@@ -222,9 +222,9 @@
         return this.get(result || null);
       }
     },
-    /*Define freezeEnums() as a property of the prototype.
-    make enumerable items nonconfigurable and deep freeze the properties. Throw Error on property setter.
-    */
+/**Define freezeEnums() as a property of the prototype.
+  make enumerable items nonconfigurable and deep freeze the properties. Throw Error on property setter.
+ */
 freezeEnums: function(){
 
   deepFreezeEnums(this);

--- a/test/enumTest.js
+++ b/test/enumTest.js
@@ -329,7 +329,7 @@ describe('Enum', function() {
 
         var myEnum;
         before(function(){
-        myEnum = new e{'A':1, 'B':2, 'C':4}; 
+        myEnum = new e({'A':1, 'B':2, 'C':4}); 
         });
 
         it('can not extend after creation, and remains persistent', function(){
@@ -381,8 +381,8 @@ describe('Enum', function() {
 
         it('creates unique identity for each property', function(){
 
-          var myEnum1 = new e{'A':1, 'B':2, 'C':4};
-          var myEnum2 = new e{'A':1, 'B':2, 'C':4};
+          var myEnum1 = new e({'A':1, 'B':2, 'C':4});
+          var myEnum2 = new e({'A':1, 'B':2, 'C':4});
           expect(myEnum1.A).not.to.equal(myEnum2.A);
           expect(myEnum1.B).not.to.equal(myEnum2.B);
           expect(myEnum1.C).not.to.equal(myEnum2.C);

--- a/test/enumTest.js
+++ b/test/enumTest.js
@@ -332,17 +332,12 @@ describe('Enum', function() {
         myEnum = new e({'A':1, 'B':2, 'C':4}); 
         });
 
-        it('can not extend after creation, and remains persistent', function(){
-      
-          expect(function(){
-            Object.defineProperty(myEnum, 'D', {value: 8});
-          }).to.throwError();
-          expect(myEnum.D).to.be(undefined);
-          expect(myEnum).not.to.have.property('D', 8);
-          expect(myEnum).to.equal(myEnum);
+        it('can not extend after creation', function(){
+          var extendMyEnum = Object.isExtensible(myEnum);
+          expect(extendMyEnum).to.be(false);
          });
 
-        it('does not accept changes to property values, throws', function(){
+        it('does not accept changes to existing property values, throws', function(){
 
           expect(myEnum).to.have.property('C');
           expect(function(){
@@ -366,9 +361,8 @@ describe('Enum', function() {
 
         it('is persistent to deletes', function(){
 
-          expect(function(){
-            return delete myEnum['A'];
-          }).to.be(false);
+          var deleteEnumItem = delete myEnum['A'];
+          expect(deleteEnumItem).to.be(false);
           expect(myEnum.get('A')).to.be(1);
           expect(myEnum).to.equal(myEnum); 
         });

--- a/test/enumTest.js
+++ b/test/enumTest.js
@@ -324,6 +324,78 @@ describe('Enum', function() {
       });
 
     });
+      
+      describe('on an enum object', function(){
+
+        var myEnum;
+        before(function(){
+        myEnum = new e{'A':1, 'B':2, 'C':4}; 
+        });
+
+        it('can not extend after creation, and remains persistent', function(){
+      
+          expect(myEnum).not.to.have.property('D', 8);
+          myEnum.D = 8;
+          expect(myEnum.D).to.be(undefined);
+          expect(myEnum.D.value).to.be(undefined); 
+          expect(myEnum.get('D')).to.be(undefined);
+          expect(function(){
+            Object.defineProperty(myEnum, 'D', {value: 8});
+          }).to.throwError();
+          expect(myEnum).to.equal(myEnum);
+         });
+
+        it('does not accept changes to property values, throws', function(){
+
+          expect(myEnum).to.have.property('C');
+          expect(function(){
+            myEnum['C'] = 3;
+          }).to.throwError("The value can not be set; Enum Type is not extensible.");
+          expect(function(){
+            Object.defineProperty(myEnum, 'C', {value: 3});
+          }).to.throwError();
+          expect(myEnum).to.equal(myEnum);
+        });
+
+        it('can not define new properties, throws', function(){
+
+           expect(function(){
+            Object.defineProperty(myEnum, 'D', {writable: true, enumerable:true});
+          }).to.throwError();
+           expect(myEnum.D).to.be(undefined); 
+           expect(myEnum).not.to.have.property('D');
+           expect(myEnum).to.equal(myEnum); 
+        });
+
+        it('is persistent to deletes', function(){
+
+          var deleteEnumItem;
+          before(function(){
+            deleteEnumItem = delete myEnum['A'];
+          });
+          expect(myEnum).to.have.property('A', 1);
+          expect(deleteEnumItem).to.be(false);
+          expect(myEnum.get('A')).to.be.(1);
+          expect(myEnum).to.equal(myEnum); 
+        });
+
+        it('creates unique identity for each property', function(){
+
+          var myEnum1 = new e{'A':1, 'B':2, 'C':4};
+          var myEnum2 = new e{'A':1, 'B':2, 'C':4};
+          expect(myEnum1.A).not.to.equal(myEnum2.A);
+          expect(myEnum1.B).not.to.equal(myEnum2.B);
+          expect(myEnum1.C).not.to.equal(myEnum2.C);
+          expect(myEnum1).not.to.equal(myEnum2);
+        });
+
+        it('respects the order of properties for equality', function(){
+          var m1 = Object.keys(myEnum);
+          var m2 = Object.keys(myEnum).reverse();
+          expect(m1).not.to.equal(m2);
+        });
+
+     }); 
 
     describe('beeing flagged', function() {
 

--- a/test/enumTest.js
+++ b/test/enumTest.js
@@ -334,14 +334,12 @@ describe('Enum', function() {
 
         it('can not extend after creation, and remains persistent', function(){
       
-          expect(myEnum).not.to.have.property('D', 8);
           myEnum.D = 8;
-          expect(myEnum.D).to.be(undefined);
-          expect(myEnum.D.value).to.be(undefined); 
-          expect(myEnum.get('D')).to.be(undefined);
           expect(function(){
             Object.defineProperty(myEnum, 'D', {value: 8});
           }).to.throwError();
+          expect(myEnum.D).to.be(undefined);
+          expect(myEnum).not.to.have.property('D', 8);
           expect(myEnum).to.equal(myEnum);
          });
 
@@ -373,7 +371,6 @@ describe('Enum', function() {
           before(function(){
             deleteEnumItem = delete myEnum['A'];
           });
-          expect(myEnum).to.have.property('A', 1);
           expect(deleteEnumItem).to.be(false);
           expect(myEnum.get('A')).to.be(1);
           expect(myEnum).to.equal(myEnum); 

--- a/test/enumTest.js
+++ b/test/enumTest.js
@@ -375,7 +375,7 @@ describe('Enum', function() {
           });
           expect(myEnum).to.have.property('A', 1);
           expect(deleteEnumItem).to.be(false);
-          expect(myEnum.get('A')).to.be.(1);
+          expect(myEnum.get('A')).to.be(1);
           expect(myEnum).to.equal(myEnum); 
         });
 

--- a/test/enumTest.js
+++ b/test/enumTest.js
@@ -346,6 +346,7 @@ describe('Enum', function() {
           expect(function(){
             Object.defineProperty(myEnum, 'C', {value: 3, writable:true, configurable: true});
           }).to.throwError();
+          expect(myEnum.get('C')).to.have.property('value', 4);
           expect(myEnum).to.equal(myEnum);
         });
 
@@ -363,7 +364,8 @@ describe('Enum', function() {
 
           var deleteEnumItem = delete myEnum['A'];
           expect(deleteEnumItem).to.be(false);
-          expect(myEnum.get('A')).to.be(1);
+          expect(myEnum).to.have.property('A');
+          expect(myEnum.get('A')).to.have.property('value', 1);
           expect(myEnum).to.equal(myEnum); 
         });
 

--- a/test/enumTest.js
+++ b/test/enumTest.js
@@ -334,7 +334,6 @@ describe('Enum', function() {
 
         it('can not extend after creation, and remains persistent', function(){
       
-          myEnum.D = 8;
           expect(function(){
             Object.defineProperty(myEnum, 'D', {value: 8});
           }).to.throwError();
@@ -350,7 +349,7 @@ describe('Enum', function() {
             myEnum['C'] = 3;
           }).to.throwError("The value can not be set; Enum Type is not extensible.");
           expect(function(){
-            Object.defineProperty(myEnum, 'C', {value: 3});
+            Object.defineProperty(myEnum, 'C', {value: 3, writable:true, configurable: true});
           }).to.throwError();
           expect(myEnum).to.equal(myEnum);
         });
@@ -367,11 +366,9 @@ describe('Enum', function() {
 
         it('is persistent to deletes', function(){
 
-          var deleteEnumItem;
-          before(function(){
-            deleteEnumItem = delete myEnum['A'];
-          });
-          expect(deleteEnumItem).to.be(false);
+          expect(function(){
+            return delete myEnum['A'];
+          }).to.be(false);
           expect(myEnum.get('A')).to.be(1);
           expect(myEnum).to.equal(myEnum); 
         });


### PR DESCRIPTION
*Added constructor properties to prototypes for inheritance
*Added freezeEnum property to Enum to ensure type safety for instances of enum types.
Please see the comments for more details.