### PR TITLE
Implement the "ref type interface"

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ var myEnum = new Enum(['A', 'B', 'C'], { separator: ' | ' });
 // if you want your enum to have a name define it in the options
 var myEnum = new Enum(['A', 'B', 'C'], { name: 'MyEnum' });
 
+// if you want your enum to have an explicit "endianness", define it in the options
+// (defaults to `os.endianness()`)
+var myEnum = new Enum(['A', 'B', 'C'], { endianness: 'BE' });
+
 // or
 var myEnum = new Enum(['A', 'B', 'C'], 'MyEnum');
 

--- a/lib/enum.js
+++ b/lib/enum.js
@@ -2,6 +2,8 @@
 
   "use strict";
 
+  var endianness = require('os').endianness();
+
   /**
    * Represents an Item of an Enum.
    * @param {String} key   The Enum key.
@@ -87,6 +89,7 @@
 
     this._options = options || {};
     this._options.separator = this._options.separator || ' | ';
+    this._options.endianness = this._options.endianness || endianness;
 
     this.enums = [];
 
@@ -133,6 +136,15 @@
     /*constructor reference so that, this.constructor===Enum//=>true */
     constructor: Enum,
 
+    /* implement the "ref type interface", so that Enum types can
+     * be used in `node-ffi` function declarations and invokations.
+     * In C, these Enums act as `uint32_t` types.
+     *
+     * https://github.com/TooTallNate/ref#the-type-interface
+     */
+    size: 4,
+    indirection: 1,
+
     /**
      * Returns the appropriate EnumItem key.
      * @param  {EnumItem || String || Number} key The object to get with.
@@ -166,8 +178,13 @@
      * @param  {EnumItem || String || Number} key The object to get with.
      * @return {EnumItem}                         The get result.
      */
-    get: function(key) {
+    get: function(key, offset) {
       if (key === null || key === undefined) return null;
+
+      // Buffer instance support, part of the ref Type interface
+      if (Buffer.isBuffer(key)) {
+        key = key['readUInt32' + this.endianness](offset || 0);
+      }
 
       if (key instanceof EnumItem || (typeof(key) === 'object' && key.key !== undefined && key.value !== undefined)) {
         var foundIndex = this.enums.indexOf(key);
@@ -220,6 +237,21 @@
         }
 
         return this.get(result || null);
+      }
+    },
+
+    /**
+     * Sets the Enum "value" onto the give `buffer` at the specified `offset`.
+     * Part of the ref "Type interface".
+     *
+     * @param  {Buffer} buffer The Buffer instance to write to.
+     * @param  {Number} offset The offset in the buffer to write to. Default 0.
+     * @param  {EnumItem || String || Number} value The EnumItem to write.
+     */
+    set: function (buffer, offset, value) {
+      var item = this.get(value);
+      if (item) {
+        return buffer['writeUInt32' + this.endianness](item.value, offset || 0);
       }
     },
 

--- a/lib/enum.js
+++ b/lib/enum.js
@@ -183,7 +183,7 @@
 
       // Buffer instance support, part of the ref Type interface
       if (Buffer.isBuffer(key)) {
-        key = key['readUInt32' + this.endianness](offset || 0);
+        key = key['readUInt32' + this._options.endianness](offset || 0);
       }
 
       if (key instanceof EnumItem || (typeof(key) === 'object' && key.key !== undefined && key.value !== undefined)) {
@@ -251,7 +251,7 @@
     set: function (buffer, offset, value) {
       var item = this.get(value);
       if (item) {
-        return buffer['writeUInt32' + this.endianness](item.value, offset || 0);
+        return buffer['writeUInt32' + this._options.endianness](item.value, offset || 0);
       }
     },
 

--- a/test/enumTest.js
+++ b/test/enumTest.js
@@ -1,4 +1,5 @@
 var expect = expect || require('expect.js'),
+    endianness = require('os').endianness(),
     e = this.Enum || require('../index');
 
 describe('Enum', function() {
@@ -471,6 +472,48 @@ describe('Enum', function() {
         var myEnum2 = new e({'A': 1, 'B': 2, 'C': 4});
 
         expect(myEnum2.get(myEnum1.A)).to.eql(null);
+
+      });
+
+    });
+
+    describe('ref Type interface', function () {
+
+      it('should define a `size` Number', function () {
+
+        var myEnum = new e(['A', 'B', 'C']);
+
+        expect(myEnum.size).to.be.a('number');
+
+      });
+
+      it('should define an `indirection` Number', function () {
+
+        var myEnum = new e(['A', 'B', 'C']);
+
+        expect(myEnum.indirection).to.be.a('number');
+
+      });
+
+      it('should work with Buffer for `get()`', function () {
+
+        var myEnum = new e(['A', 'B', 'C']);
+        var buffer = new Buffer(myEnum.size);
+
+        buffer['writeUInt32' + endianness](myEnum.B.value, 0);
+
+        expect(myEnum.get(buffer)).to.eql(myEnum.B);
+
+      });
+
+      it('should work with Buffer for `set()`', function () {
+
+        var myEnum = new e(['A', 'B', 'C']);
+        var buffer = new Buffer(myEnum.size);
+
+        myEnum.set(buffer, 0, myEnum.B);
+
+        expect(buffer['readUInt32' + endianness](0)).to.eql(myEnum.B.value);
 
       });
 


### PR DESCRIPTION
Closes #7.
Need to require the `os` module now, but at least it's a node.js core module, so there's still no external dependencies. Let me know what you think!