### PR TITLE
make EnumItem#valueOf() return `value`

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,11 +134,11 @@ myItem.has(1)
 
 
 // other functions
-myItem.toString() // returns A | C
-myItem.toJSON() // returns A | C
-myItem.valueOf() // returns A | C
+myItem.toString() // returns 'A | C'
+myItem.toJSON() // returns '"A | C"'
+myItem.valueOf() // returns 3
 
-JSON.stringify(myItem) // returns A | C
+JSON.stringify(myItem) // returns '"A | C"'
 
 //Type Safety:
 //Newly created enumerable objects are Type-Safe in a way that it's non-configurable and no longer extensible.

--- a/lib/enum.js
+++ b/lib/enum.js
@@ -68,7 +68,7 @@
      * @return {String} The value to compare with.
      */
     valueOf: function() {
-      return this.key;
+      return this.value;
     }
 
   };

--- a/test/enumTest.js
+++ b/test/enumTest.js
@@ -147,8 +147,8 @@ describe('Enum', function() {
 
             it('with ==', function() {
 
-              expect(myEnum.A == 'A').to.be.ok();
-              expect(myEnum.C == 'C').to.be.ok();
+              expect(myEnum.A == myEnum.A.value).to.be.ok();
+              expect(myEnum.C == myEnum.C.value).to.be.ok();
 
             });
 
@@ -309,9 +309,19 @@ describe('Enum', function() {
 
         });
 
-        it('call valueOf and get the key', function() {
+        it('call valueOf and get the value', function() {
 
-          expect(myEnum.A.valueOf()).to.eql('A');
+          expect(myEnum.A.valueOf()).to.eql(myEnum.A.value);
+
+        });
+
+        it('use JavaScript | operator', function() {
+
+          expect(myEnum.A | myEnum.B).to.eql(myEnum.getValue('A | B'));
+
+          expect(myEnum.A | myEnum.C).to.eql(myEnum.getValue('A | C'));
+
+          expect(myEnum.A | myEnum.B | myEnum.C).to.eql(myEnum.getValue('A | B | C'));
 
         });
 


### PR DESCRIPTION
Instead of `key`. This way, the JavaScript `|` operator can be used just like it would be used in C.

This is technically a breaking change, so we should consider bumping to v1.0.0 once this (and #9 :wink:) is merged.

Closes #8.