### PR TITLE
define standalone variable

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,6 +8,7 @@ var version = require('./package.json').version;
 gulp.task('build', function() {
   gulp.src('lib/enum.js')
     .pipe(browserify({
+      standalone: 'Enum',
       insertGlobals : true,
       debug : !gulp.env.production
     }))

--- a/lib/enum.js
+++ b/lib/enum.js
@@ -310,8 +310,4 @@ Enum.register = function(key) {
   }
 };
 
-if (typeof (window) !== 'undefined') {
-  window.Enum = Enum;
-}
-
 module.exports = Enum;


### PR DESCRIPTION
Browserify knows `--standalone` which sets a global variable if no module system is found.

```
  --standalone -s  Generate a UMD bundle for the supplied export name.
                   This bundle works with other module systems and sets the name
                   given as a window global if no module system is found.
```