### PR TITLE
Question: Why return  null instead of undefined for invalid enum lookups?

### DIFF
--- a/lib/enum.js
+++ b/lib/enum.js
@@ -203,8 +203,6 @@ Enum.prototype = {
     var item = this.get(key);
     if (item) {
       return item.value;
-    } else {
-      return null;
     }
   },
 

--- a/lib/enum.js
+++ b/lib/enum.js
@@ -189,8 +189,6 @@ Enum.prototype = {
     var item = this.get(value);
     if (item) {
       return item.key;
-    } else {
-      return 'Undefined';
     }
   },
 

--- a/lib/enum.js
+++ b/lib/enum.js
@@ -214,7 +214,7 @@ Enum.prototype = {
    * @return {EnumItem}                         The get result.
    */
   get: function(key, offset) {
-    if (key === null || key === undefined) return null;
+    if (key === null || key === undefined) return;
 
     // Buffer instance support, part of the ref Type interface
     if (Buffer.isBuffer(key)) {

--- a/lib/enum.js
+++ b/lib/enum.js
@@ -223,7 +223,7 @@ Enum.prototype = {
         return key;
       }
       if (!this.isFlaggable || (this.isFlaggable && key.key.indexOf(this._options.separator) < 0)) {
-        return null;
+        return;
       }
       return this.get(key.key);
     } else if (isString(key)) {

--- a/test/enumTest.js
+++ b/test/enumTest.js
@@ -473,7 +473,7 @@ describe('Enum', function() {
 
         it('it should return undefined', function() {
 
-          expect(myNonFlaggedEnum.get(5)).to.not.be.ok();
+          expect(myNonFlaggedEnum.get(5)).to.be(undefined);
 
         });
 

--- a/test/enumTest.js
+++ b/test/enumTest.js
@@ -483,13 +483,13 @@ describe('Enum', function() {
 
     describe('and getting an item of it from an other enum', function () {
 
-      it('it should return null', function() {
+      it('it should return undefined', function() {
 
         var myEnum1 = new e(['A', 'B', 'C']);
 
         var myEnum2 = new e({'A': 1, 'B': 2, 'C': 4});
 
-        expect(myEnum2.get(myEnum1.A)).to.eql(null);
+        expect(myEnum2.get(myEnum1.A)).to.be(undefined);
 
       });
 

--- a/test/enumTest.js
+++ b/test/enumTest.js
@@ -216,27 +216,24 @@ describe('Enum', function() {
 
           });
 
-        });
+          describe('undefined', function() {
 
-        describe('call get with null and get', function() {
+            it('for null', function() {
+              expect(myEnum.get(null)).to.be(undefined);
+            });
 
-          it('null', function() {
+            it('for undefined', function() {
+              expect(myEnum.get(undefined)).to.be(undefined);
+            });
 
-            expect(myEnum.get(null)).to.eql(null);
-
-          });
-
-        });
-
-        describe('call get with undefined and get', function() {
-
-          it('null', function() {
-
-            expect(myEnum.get(undefined)).to.eql(null);
+            it('for invalid key/value', function() {
+              expect(myEnum.get('X')).to.be(undefined);
+            });
 
           });
 
         });
+
 
         describe('call getValue and get', function() {
 
@@ -446,26 +443,6 @@ describe('Enum', function() {
         it('it should return undefined', function() {
 
           expect(myNonFlaggedEnum.get(5)).to.not.be.ok();
-
-        });
-
-      });
-
-      describe('call get with an non valid value and get', function() {
-
-        it('null', function() {
-
-          expect(myNonFlaggedEnum.get(12345)).to.eql(null);
-
-        });
-
-      });
-
-      describe('call get with 0 and get', function() {
-
-        it('null', function() {
-
-          expect(myNonFlaggedEnum.get(0)).to.not.eql(null);
 
         });
 

--- a/test/enumTest.js
+++ b/test/enumTest.js
@@ -261,6 +261,22 @@ describe('Enum', function() {
 
           });
 
+          describe('undefined', function() {
+
+            it('for null', function() {
+              expect(myEnum.getValue(null)).to.be(undefined);
+            });
+
+            it('for undefined', function() {
+              expect(myEnum.getValue(undefined)).to.be(undefined);
+            });
+
+            it('for invalid key/value', function() {
+              expect(myEnum.getValue('X')).to.be(undefined);
+            });
+
+          });
+
         });
 
         describe('call getKey and get', function() {

--- a/test/enumTest.js
+++ b/test/enumTest.js
@@ -305,6 +305,21 @@ describe('Enum', function() {
 
           });
 
+          describe('undefined', function() {
+
+            it('for null', function() {
+              expect(myEnum.getKey(null)).to.be(undefined);
+            });
+
+            it('for undefined', function() {
+              expect(myEnum.getKey(undefined)).to.be(undefined);
+            });
+
+            it('for invalid key/value', function() {
+              expect(myEnum.getKey('X')).to.be(undefined);
+            });
+
+          });
         });
 
       });


### PR DESCRIPTION
I just got tripped up by Enum returning `null` instead of `undefined` for missing enum values.

``` javascript
var myEnum = new Enum(['A', 'B']);
myEnum.get('C'); // => null
```

I would have expected `undefined` not `null`, because null is a legitimate value in JavaScript. `undefined` on the other hand, represents a value that has not been set; which I think more accurately describes the missing enum value.

``` javascript
var x = {a:1};
x.b // => undefined

y // => undefined
```

`null` carries the connotation from other languages of being an object reference that happens to currently be empty. Since the value being requested of the enum is non existent, (which is different from being a placeholder for an empty object), I submit that it _ought_ to be returning `undefined`, instead.

Thoughts? I see that there are tests explicitly testing for `null`, so I assume there is a particular reason `null` was chosen over `undefined`?