### PR TITLE
simplify getting a flaggable enum by 'or' value

### DIFF
--- a/lib/enum.js
+++ b/lib/enum.js
@@ -257,24 +257,19 @@ Enum.prototype = {
         }
       }
 
-      var result = null;
+      var result = [];
 
       if (this.isFlaggable) {
         for (var n in this) {
           if (this.hasOwnProperty(n)) {
             if ((key & this[n].value) !== 0) {
-              if (result) {
-                result += this._options.separator;
-              } else {
-                result = '';
-              }
-              result += n;
+              result.push(n);
             }
           }
         }
       }
 
-      return this.get(result || null);
+      return this.get(result.join(this._options.separator));
     }
   },
 


### PR DESCRIPTION
Not sure if you like this change, but it looked awkward as I was trying to
understand it when working on the other PRs.

Now that `null` as a `get` argument isn't a special case, this can be
simplified to just pushing matching keys into an array and joining with the
separator.

No real change in functionality, only clarity (IMO).