### PR TITLE
Fix reserved-word guard

### DIFF
--- a/lib/enum.es6
+++ b/lib/enum.es6
@@ -264,6 +264,6 @@ var reservedKeys = ['_options', 'get', 'getKey', 'getValue', 'enums', 'isFlaggab
 
 function guardReservedKeys(customName, key) {
   if ((customName && key === 'name') || indexOf.call(reservedKeys, key) >= 0) {
-    throw new Error("Enum key \"" + key + "\" is a reserved word!");
+    throw new Error(`Enum key ${key} is a reserved word!`);
   }
 }

--- a/lib/enum.es6
+++ b/lib/enum.es6
@@ -7,6 +7,8 @@ import { indexOf } from './indexOf';
 
 const endianness = os.endianness();
 
+var reservedKeys = ['_options', 'get', 'getKey', 'getValue', 'enums', 'isFlaggable'];
+
 /**
  * Represents an Enum with enum items.
  * @param {Array || Object}  map     This are the enum items.
@@ -44,7 +46,7 @@ export default class Enum {
     }
 
     for (var member in map) {
-      if (this._options.name && ['name', '_options', 'get', 'getKey', 'getValue', 'enums', 'isFlaggable'].includes(member)) {
+      if (indexOf.call(reservedKeys, member) >= 0) {
         throw new Error("Enum key \"" + member + "\" is a reserved word!");
       }
       this[member] = new EnumItem(member, map[member], { ignoreCase: this._options.ignoreCase });
@@ -259,5 +261,4 @@ export default class Enum {
     }
   }
 };
-
 

--- a/lib/enum.es6
+++ b/lib/enum.es6
@@ -7,8 +7,6 @@ import { indexOf } from './indexOf';
 
 const endianness = os.endianness();
 
-var reservedKeys = ['_options', 'get', 'getKey', 'getValue', 'enums', 'isFlaggable'];
-
 /**
  * Represents an Enum with enum items.
  * @param {Array || Object}  map     This are the enum items.
@@ -46,9 +44,7 @@ export default class Enum {
     }
 
     for (var member in map) {
-      if ((this._options.name && member === 'name') || indexOf.call(reservedKeys, member) >= 0) {
-        throw new Error("Enum key \"" + member + "\" is a reserved word!");
-      }
+      guardReservedKeys(this._options.name, member);
       this[member] = new EnumItem(member, map[member], { ignoreCase: this._options.ignoreCase });
       this.enums.push(this[member]);
     }
@@ -262,3 +258,12 @@ export default class Enum {
   }
 };
 
+// private
+
+var reservedKeys = ['_options', 'get', 'getKey', 'getValue', 'enums', 'isFlaggable'];
+
+function guardReservedKeys(customName, key) {
+  if ((customName && key === 'name') || indexOf.call(reservedKeys, key) >= 0) {
+    throw new Error("Enum key \"" + key + "\" is a reserved word!");
+  }
+}

--- a/lib/enum.es6
+++ b/lib/enum.es6
@@ -46,7 +46,7 @@ export default class Enum {
     }
 
     for (var member in map) {
-      if (indexOf.call(reservedKeys, member) >= 0) {
+      if ((this._options.name && member === 'name') || indexOf.call(reservedKeys, member) >= 0) {
         throw new Error("Enum key \"" + member + "\" is a reserved word!");
       }
       this[member] = new EnumItem(member, map[member], { ignoreCase: this._options.ignoreCase });

--- a/test/enumTest.js
+++ b/test/enumTest.js
@@ -564,6 +564,19 @@
 
       });
 
+      describe('with a reserved enumitem name', function() {
+        var reservedKeys = [ '_options', 'get', 'getKey', 'getValue', 'enums', 'isFlaggable' ];
+
+        it('throws an error', function() {
+          for (var k = 0; k < reservedKeys.length; k++) {
+
+            expect(function(){ new e([reservedKeys[k]]); }).to.throwError(new RegExp(reservedKeys[k]));
+
+          }
+        });
+
+      });
+
     });
 
   });

--- a/test/enumTest.js
+++ b/test/enumTest.js
@@ -597,6 +597,10 @@
           expect(myEnum.name).to.be('BlueFish');
         });
 
+        it('cannot accept an enumitem also named `name`', function() {
+          expect(function(){ new e(['name'], 'customName'); }).to.throwError(/name/);
+        });
+
       });
 
     });

--- a/test/enumTest.js
+++ b/test/enumTest.js
@@ -575,6 +575,12 @@
           }
         });
 
+        it('does not throw an error for `name`', function() {
+
+          expect(function(){ new e(['name']); }).not.to.throwError();
+
+        });
+
       });
 
     });

--- a/test/enumTest.js
+++ b/test/enumTest.js
@@ -583,6 +583,22 @@
 
       });
 
+      describe('with a custom name', function() {
+
+        it('can be given as second argument', function() {
+          var myEnum = new e(['oneFish', 'twoFish'], 'RedFish');
+
+          expect(myEnum.name).to.be('RedFish');
+        });
+
+        it('can be given as an option', function() {
+          var myEnum = new e(['oneFish', 'twoFish'], { name: 'BlueFish' });
+
+          expect(myEnum.name).to.be('BlueFish');
+        });
+
+      });
+
     });
 
   });

--- a/test/test.html
+++ b/test/test.html
@@ -8,7 +8,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/expect.js/0.2.0/expect.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/mocha/2.1.0/mocha.min.js"></script>
   <script>mocha.setup('bdd')</script>
-  <script src="../enum-2.0.0.min.js"></script>
+  <script src="../enum-2.0.1.js"></script>
   <script src="buffer.js"></script>
   <script src="enumTest.js"></script>
   <script>


### PR DESCRIPTION
There were two regressions in the babel port:

1. the `name` option is not a prequisite for the reserved words being reserved.
Only the `name` key is reserved if the enum is given a custom name. The rest of the keys are reserved unconditionally.
2. Array.prototype.includes has virtually zero browser support (it's not in
Chrome, Firefox, Safari, Opera, or IE) nor is it even in Node (not even iojs). It was never caught in the tests, though, because there weren't any tests that provided a custom name. (Which normally shouldn't have been a prerequisite, but was in this case being masked by bug # 1 above.)