### PR TITLE
not ignoring `enum.*.js` so that it is available for browsers to use

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,5 @@
 /.*
 /gulpfile.js
-/enum-*.js
 /test
 /bench
 /lib


### PR DESCRIPTION
fix for #25 