### PR TITLE
Replace Buffer.isBuffer with is-buffer to decrease the bundle size

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -55,7 +55,6 @@ gulp.task('build', ['es6-build'], function() {
   return gulp.src('index.js')
     .pipe(browserify({
       standalone: 'Enum',
-      insertGlobals : true,
       debug : !gulp.env.production
     }))
     .pipe(rename('enum-' + version + '.js'))

--- a/lib/enum.es6
+++ b/lib/enum.es6
@@ -4,6 +4,7 @@ import os from 'os';
 import EnumItem from './enumItem';
 import { isString } from './isType';
 import { indexOf } from './indexOf';
+import isBuffer from 'is-buffer';
 
 const endianness = os.endianness();
 
@@ -116,7 +117,7 @@ export default class Enum {
     if (key === null || key === undefined) {
       return;
     } // Buffer instance support, part of the ref Type interface
-    if (Buffer.isBuffer(key)) {
+    if (isBuffer(key)) {
       key = key["readUInt32" + this._options.endianness](offset || 0);
     }
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
   "directories": {
     "lib": "./lib"
   },
-  "dependencies": {},
+  "dependencies": {
+    "is-buffer": "^1.1.0"
+  },
   "devDependencies": {
     "expect.js": ">= 0.1.2",
     "gulp": "^3.8.11",


### PR DESCRIPTION
These two commits reduce the bundle size significantly. The tests still run.
```
enum.js 146 kB -> 39 kB
enum.min.js 27 kB -> 6.9 kB
```