### PR TITLE
Add isDefined function to Enum class

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.js text eol=lf
+*.es6 text eol=lf

--- a/lib/enum.es6
+++ b/lib/enum.es6
@@ -254,6 +254,15 @@ export default class Enum {
   }
 
   /**
+   * Return true whether the enumItem parameter passed in is an EnumItem object and 
+   * has been included as constant of this Enum   
+   * @param  {EnumItem} enumItem
+   */
+  isDefined(enumItem){
+    return enumItem instanceof EnumItem && enumItem === this.enums.find((e) => e.is(enumItem));
+  }
+
+  /**
    * Returns JSON object representation of this Enum.
    * @return {String} JSON object representation of this Enum.
    */

--- a/test/enumTest.js
+++ b/test/enumTest.js
@@ -131,6 +131,29 @@
 
           describe('compare', function() {
 
+            describe('an item', function() {
+
+              it('has been defined', function() {
+
+                expect(myEnum.isDefined(myEnum.A)).to.be(true);
+
+                var myEnum2 = new e({'A': 1, 'B': 2, 'C': 4});
+                expect(myEnum2.isDefined(myEnum2.B)).to.be(true);
+                
+                expect(myEnum.isDefined(myEnum2.C)).to.be(false);
+                expect(myEnum2.isDefined(myEnum.A)).to.be(false);
+                
+                expect(myEnum.isDefined(myEnum)).to.be(false);
+                expect(myEnum.isDefined(myEnum2)).to.be(false);
+                
+                expect(myEnum.isDefined()).to.be(false);
+                expect(myEnum.isDefined({})).to.be(false);
+                expect(myEnum.isDefined(null)).to.be(false);
+                expect(myEnum.isDefined(undefined)).to.be(false);
+
+              });
+            });
+            
             describe('an item and an item', function() {
 
               it('with is', function() {


### PR DESCRIPTION
The changes are pointing to add a straightforward way to find out whether an EnumItem object has been created as part of Enum object's constants.