### PR TITLE
Add isDefined function to Enum type

### DIFF
--- a/lib/enum.es6
+++ b/lib/enum.es6
@@ -2,7 +2,7 @@
 
 import os from 'os';
 import EnumItem from './enumItem';
-import { isString } from './isType';
+import { isString, isNumber } from './isType';
 import { indexOf } from './indexOf';
 import isBuffer from 'is-buffer';
 
@@ -253,6 +253,19 @@ export default class Enum {
     return this;
   }
 
+  /**
+   * Return true whether the enumItem parameter passed in is an EnumItem object and 
+   * has been included as constant of this Enum   
+   * @param  {EnumItem} enumItem
+   */
+  isDefined(enumItem){
+    let condition = (e) => e === enumItem;
+    if (isString(enumItem) || isNumber(enumItem)) {
+      condition = (e) => e.is(enumItem);
+    }
+    return this.enums.some(condition);
+  }
+  
   /**
    * Returns JSON object representation of this Enum.
    * @return {String} JSON object representation of this Enum.

--- a/lib/isType.es6
+++ b/lib/isType.es6
@@ -1,3 +1,4 @@
 export const isType = (type, value) => typeof value === type;
 export const isObject = (value) => isType("object", value);
 export const isString = (value) => isType("string", value);
+export const isNumber = (value) => isType("number", value);

--- a/test/enumTest.js
+++ b/test/enumTest.js
@@ -131,6 +131,36 @@
 
           describe('compare', function() {
 
+            describe('an item', function() {
+
+              it('has been defined', function() {
+
+                expect(myEnum.isDefined(myEnum.A)).to.be(true);
+                expect(myEnum.isDefined('A')).to.be(true);
+                expect(myEnum.isDefined(1)).to.be(true);
+
+                var myEnum2 = new e({'A': 1, 'B': 2, 'C': 4});
+                expect(myEnum2.isDefined(myEnum2.C)).to.be(true);
+                expect(myEnum2.isDefined('C')).to.be(true);
+                expect(myEnum2.isDefined(4)).to.be(true);
+                
+                expect(myEnum.isDefined(myEnum2.C)).to.be(false);
+                expect(myEnum2.isDefined(myEnum.A)).to.be(false);
+                
+                expect(myEnum.isDefined(myEnum)).to.be(false);
+                expect(myEnum.isDefined(myEnum2)).to.be(false);
+                
+                expect(myEnum.isDefined()).to.be(false);
+                expect(myEnum.isDefined('Z')).to.be(false);
+                expect(myEnum.isDefined(10)).to.be(false);
+                expect(myEnum.isDefined({})).to.be(false);
+                expect(myEnum.isDefined(null)).to.be(false);
+                expect(myEnum.isDefined(undefined)).to.be(false);
+
+              });
+
+            });
+            
             describe('an item and an item', function() {
 
               it('with is', function() {


### PR DESCRIPTION
The changes are pointing to add a straightforward way to find out whether an EnumItem or either its constant or value have been defined as part of Enum type instance.